### PR TITLE
Add dependabot-alerts.yml

### DIFF
--- a/.github/workflows/dependabot-alerts.yml
+++ b/.github/workflows/dependabot-alerts.yml
@@ -1,0 +1,11 @@
+name: Dependabot alerts
+on:
+  workflow_dispatch:
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: hashicorp/vault-action@v2.0.0
+        with:
+          url: https://localhost:8200
+          secrets: dummy


### PR DESCRIPTION
Test for Dependabot alerts with [CVE-2021-32074](https://nvd.nist.gov/vuln/detail/CVE-2021-32074)

- https://github.com/advisories/GHSA-4mgv-m5cm-f9h7